### PR TITLE
Add use_psram param description to esp32_rmt_led_strip.rst

### DIFF
--- a/components/light/esp32_rmt_led_strip.rst
+++ b/components/light/esp32_rmt_led_strip.rst
@@ -54,6 +54,7 @@ Configuration variables
   A time interval used to limit the number of commands a light can handle per second. For example
   16ms will limit the light to a refresh rate of about 60Hz. Defaults to sending commands as quickly as
   changes are made to the lights.
+- **use_psram** (*Optional*, boolean): Set to ``false`` to force internal RAM allocation even if you have the the PSRAM component enabled. This can be useful if you're experiencing issues like flickering with your leds strip. Defaults to ``true``.
 
 - All other options from :ref:`Light <config-light>`.
 


### PR DESCRIPTION
## Description:
Add use_psram param description to esp32_rmt_led_strip.rst

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes:** esphome/esphome#7478

## Checklist:

  - [X] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
